### PR TITLE
SUGGESTION/DISCUSSION DON'T MERGE >> Update to support CodePush cli 2.0.0

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -46,7 +46,7 @@ async function checkForUpdate(deploymentKey = null) {
     queryPackage = localPackage;
   } else {
     queryPackage = { appVersion: config.appVersion };
-    if (Platform.OS === "ios" && config.packageHash) {
+    if (config.packageHash) {
       queryPackage.packageHash = config.packageHash;
     }
   }

--- a/CodePush.js
+++ b/CodePush.js
@@ -238,15 +238,36 @@ const sync = (() => {
   const setSyncCompleted = () => { syncInProgress = false; };
 
   return (options = {}, syncStatusChangeCallback, downloadProgressCallback) => {
+    let syncStatusCallbackWithTryCatch, downloadProgressCallbackkWithTryCatch;
+    if (typeof syncStatusChangeCallback === "function") {
+      syncStatusCallbackWithTryCatch = (...args) => {
+        try {
+          syncStatusChangeCallback(...args);
+        } catch (error) {
+          log(`An error has occurred : ${error.stack}`);
+        }
+      }
+    }
+
+    if (typeof downloadProgressCallback === "function") {
+      downloadProgressCallbackkWithTryCatch = (...args) => {
+        try {
+          downloadProgressCallback(...args);
+        } catch (error) {
+          log(`An error has occurred: ${error.stack}`);
+        }
+      }
+    }
+
     if (syncInProgress) {
-      typeof syncStatusChangeCallback === "function"
-        ? syncStatusChangeCallback(CodePush.SyncStatus.SYNC_IN_PROGRESS)
+      typeof syncStatusCallbackWithTryCatch === "function"
+        ? syncStatusCallbackWithTryCatch(CodePush.SyncStatus.SYNC_IN_PROGRESS)
         : log("Sync already in progress.");
       return Promise.resolve(CodePush.SyncStatus.SYNC_IN_PROGRESS);
     }
 
     syncInProgress = true;
-    const syncPromise = syncInternal(options, syncStatusChangeCallback, downloadProgressCallback);
+    const syncPromise = syncInternal(options, syncStatusCallbackWithTryCatch, downloadProgressCallbackkWithTryCatch);
     syncPromise
       .then(setSyncCompleted)
       .catch(setSyncCompleted);

--- a/CodePush.js
+++ b/CodePush.js
@@ -482,7 +482,15 @@ function codePushify(options = {}) {
       }
 
       render() {
-        return <RootComponent {...this.props} ref={"rootComponent"} />
+        const props = {...this.props};
+
+        // we can set ref property on class components only (not stateless)
+        // check it by render method
+        if (RootComponent.prototype.render) {
+          props.ref = "rootComponent";
+        }
+
+        return <RootComponent {...props} />
       }
     }
   }

--- a/Examples/CodePushDemoApp/package.json
+++ b/Examples/CodePushDemoApp/package.json
@@ -10,7 +10,7 @@
     "react": "16.0.0-alpha.6",
     "react-native": "^0.43.2",
     "react-native-code-push": "file:../../",
-    "react-native-windows": "0.40.0-rc.1"
+    "react-native-windows": "^0.43.0-rc.0"
   },
   "devDependencies": {
     "babel-jest": "19.0.0",

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/App.config
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/App.config
@@ -1,6 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/App.xaml.cs
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/App.xaml.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Navigation;

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/CodePushDemoApp.Wpf.csproj
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/CodePushDemoApp.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.ChakraCore.1.4.1-preview-00010-42060\build\netstandard1.0\Microsoft.ChakraCore.props" Condition="Exists('..\packages\Microsoft.ChakraCore.1.4.1-preview-00010-42060\build\netstandard1.0\Microsoft.ChakraCore.props')" />
+  <Import Project="..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props" Condition="Exists('..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -102,7 +102,7 @@
   <ItemGroup>
     <Reference Include="Facebook.Yoga, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Facebook.Yoga.1.0.1-pre\lib\netstandard\Facebook.Yoga.dll</HintPath>
+      <HintPath>..\packages\Facebook.Yoga.1.2.0-pre1\lib\net45\Facebook.Yoga.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -170,10 +170,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.1.4.1-preview-00010-42060\build\netstandard1.0\Microsoft.ChakraCore.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.1.4.1-preview-00010-42060\build\netstandard1.0\Microsoft.ChakraCore.props'))" />
-    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.0.1-pre\build\netstandard\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.0.1-pre\build\netstandard\Facebook.Yoga.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props'))" />
+    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets'))" />
   </Target>
-  <Import Project="..\packages\Facebook.Yoga.1.0.1-pre\build\netstandard\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.0.1-pre\build\netstandard\Facebook.Yoga.targets')" />
+  <Import Project="..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/packages.config
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Facebook.Yoga" version="1.0.1-pre" targetFramework="net46" />
-  <package id="Microsoft.ChakraCore" version="1.4.1-preview-00010-42060" targetFramework="net46" developmentDependency="true" />
+  <package id="Facebook.Yoga" version="1.2.0-pre1" targetFramework="net46" />
+  <package id="Microsoft.ChakraCore" version="1.4.1" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp/project.json
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Facebook.Yoga": "1.0.1-pre",
+    "Facebook.Yoga": "1.2.0-pre1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
   },
   "frameworks": {

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ We try our best to maintain backwards compatability of our plugin with previous 
 | v0.34-v0.35             | v1.15-v1.17 *(RN refactored native hosting code)*    |
 | v0.36-v0.39             | v1.16-v1.17 *(RN refactored resume handler)*         |
 | v0.40-v0.42             | v1.17 *(RN refactored iOS header files)*             |
-| v0.43                   | v2.0+ *(RN refactored uimanager dependencies)*       |
-| v0.44+                  | TBD :) We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
+| v0.43-v0.44             | v2.0+ *(RN refactored uimanager dependencies)*       |
+| v0.45+                  | TBD :) We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 
 ### Supported Components
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ As new core components are released, which support referencing assets, we'll upd
 Once you've followed the general-purpose ["getting started"](http://codepush.tools/docs/getting-started.html) instructions for setting up your CodePush account, you can start CodePush-ifying your React Native app by running the following command from within your app's root directory:
 
 ```shell
-npm install --save react-native-code-push@latest
+npm install --save react-native-code-push
 ```
 
 As with all other React Native plugins, the integration experience is different for iOS and Android, so perform the following setup steps depending on which platform(s) you are targeting. Note, if you are targeting both platforms it is recommended to create separate CodePush applications for each platform.

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Additionally, you can also use any of the platform-specific tools to view the Co
 
 Note that by default, React Native logs are disabled on iOS in release builds, so if you want to view them in a release build, you need to make the following changes to your `AppDelegate.m` file:
 
-1. Add an `#import "RCTLog.h"` statement
+1. Add an `#import <React/RCTLog.h>` statement. For RN < v0.40 use: `#import "RCTLog.h"`
 
 2. Add the following statement to the top of your `application:didFinishLaunchingWithOptions` method:
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ And that's it! Now when you run or build your app, your staging builds will auto
 
 *Note: If you encounter the error message `ld: library not found for ...`, please consult [this issue](https://github.com/Microsoft/react-native-code-push/issues/426) for a possible solution.*
 
-Additionally, if you want to give them seperate names and/or icons, you can modify the `Product Name` and `Asset Catalog App Icon Set Name` build settings, which will allow your staging builds to be distinguishable from release builds when installed on the same device.
+Additionally, if you want to give them seperate names and/or icons, you can modify the `Product Bundle Identifier`, `Product Name` and `Asset Catalog App Icon Set Name` build settings, which will allow your staging builds to be distinguishable from release builds when installed on the same device.
 
 ### Dynamic Deployment Assignment
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -1,5 +1,9 @@
 package com.microsoft.codepush.react;
 
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
@@ -7,20 +11,12 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
-import android.content.Context;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 public class CodePush implements ReactPackage {
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -108,7 +108,9 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
 
             Method[] methods = jsBundleLoaderClass.getDeclaredMethods();
             for (Method method : methods) {
-                if (method.getName().equals("createFileLoader")) {
+                String createFileLoaderMethodName = latestJSBundleFile.toLowerCase().startsWith("assets://")
+                        ? "createAssetLoader" : "createFileLoader";
+                if (method.getName().equals(createFileLoaderMethodName)) {
                     createFileLoaderMethod = method;
                     break;
                 }
@@ -125,7 +127,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 // RN >= v0.34
                 latestJSBundleLoader = createFileLoaderMethod.invoke(jsBundleLoaderClass, latestJSBundleFile);
             } else if (numParameters == 2) {
-                // RN >= v0.31 && RN < v0.34
+                // RN >= v0.31 && RN < v0.34 or AssetLoader instance
                 latestJSBundleLoader = createFileLoaderMethod.invoke(jsBundleLoaderClass, getReactApplicationContext(), latestJSBundleFile);
             } else {
                 throw new NoSuchMethodException("Could not find a recognized 'createFileLoader' method");

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -1,14 +1,12 @@
 package com.microsoft.codepush.react;
 
 import android.app.Activity;
-import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.Looper;
 import android.provider.Settings;
-import android.view.Choreographer;
 
-import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -18,8 +16,8 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ChoreographerCompat;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ReactChoreographer;
 
 import org.json.JSONArray;
@@ -43,9 +41,6 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
     private SettingsManager mSettingsManager;
     private CodePushTelemetryManager mTelemetryManager;
     private CodePushUpdateManager mUpdateManager;
-
-    private static final String REACT_APPLICATION_CLASS_NAME = "com.facebook.react.ReactApplication";
-    private static final String REACT_NATIVE_HOST_CLASS_NAME = "com.facebook.react.ReactNativeHost";
 
     public CodePushNativeModule(ReactApplicationContext reactContext, CodePush codePush, CodePushUpdateManager codePushUpdateManager, CodePushTelemetryManager codePushTelemetryManager, SettingsManager settingsManager) {
         super(reactContext);
@@ -100,7 +95,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
 
     // Use reflection to find and set the appropriate fields on ReactInstanceManager. See #556 for a proposal for a less brittle way
     // to approach this.
-    private void setJSBundle(ReactInstanceManager instanceManager, String latestJSBundleFile) throws NoSuchFieldException, IllegalAccessException {
+    private void setJSBundle(ReactInstanceManager instanceManager, String latestJSBundleFile) throws IllegalAccessException {
         try {
             Field bundleLoaderField = instanceManager.getClass().getDeclaredField("mBundleLoader");
             Class<?> jsBundleLoaderClass = Class.forName("com.facebook.react.cxxbridge.JSBundleLoader");
@@ -109,7 +104,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                         ? "createAssetLoader" : "createFileLoader";
 
             Method[] methods = jsBundleLoaderClass.getDeclaredMethods();
-            for (Method method : methods) {               
+            for (Method method : methods) {
                 if (method.getName().equals(createFileLoaderMethodName)) {
                     createFileLoaderMethod = method;
                     break;
@@ -127,7 +122,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 // RN >= v0.34
                 latestJSBundleLoader = createFileLoaderMethod.invoke(jsBundleLoaderClass, latestJSBundleFile);
             } else if (numParameters == 2) {
-                // RN >= v0.31 && RN < v0.34 or AssetLoader instance
+                // AssetLoader instance
                 latestJSBundleLoader = createFileLoaderMethod.invoke(jsBundleLoaderClass, getReactApplicationContext(), latestJSBundleFile);
             } else {
                 throw new NoSuchMethodException("Could not find a recognized 'createFileLoader' method");
@@ -136,14 +131,13 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             bundleLoaderField.setAccessible(true);
             bundleLoaderField.set(instanceManager, latestJSBundleLoader);
         } catch (Exception e) {
-            // RN < v0.31
-            Field jsBundleField = instanceManager.getClass().getDeclaredField("mJSBundleFile");
-            jsBundleField.setAccessible(true);
-            jsBundleField.set(instanceManager, latestJSBundleFile);
+            CodePushUtils.log("Unable to set JSBundle - CodePush may not support this version of React Native");
+            throw new IllegalAccessException("Could not setJSBundle");
         }
     }
 
     private void loadBundle() {
+        clearLifecycleEventListener();
         mCodePush.clearDebugCacheIfNeeded();
         try {
             // #1) Get the ReactInstanceManager instance, which is what includes the
@@ -159,12 +153,11 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             setJSBundle(instanceManager, latestJSBundleFile);
 
             // #3) Get the context creation method and fire it on the UI thread (which RN enforces)
-            final Method recreateMethod = instanceManager.getClass().getMethod("recreateReactContextInBackground");
             new Handler(Looper.getMainLooper()).post(new Runnable() {
                 @Override
                 public void run() {
                     try {
-                        recreateMethod.invoke(instanceManager);
+                        instanceManager.recreateReactContextInBackground();
                         mCodePush.initializeUpdateAfterRestart();
                     } catch (Exception e) {
                         // The recreation method threw an unknown exception
@@ -181,6 +174,14 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
         }
     }
 
+    private void clearLifecycleEventListener() {
+        // Remove LifecycleEventListener to prevent infinite restart loop
+        if (mLifecycleEventListener != null) {
+            getReactApplicationContext().removeLifecycleEventListener(mLifecycleEventListener);
+            mLifecycleEventListener = null;
+        }
+    }
+
     // Use reflection to find the ReactInstanceManager. See #556 for a proposal for a less brittle way to approach this.
     private ReactInstanceManager resolveInstanceManager() throws NoSuchFieldException, IllegalAccessException {
         ReactInstanceManager instanceManager = CodePush.getReactInstanceManager();
@@ -192,37 +193,11 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
         if (currentActivity == null) {
             return null;
         }
-        try {
-            // In RN >=0.29, the "mReactInstanceManager" field yields a null value, so we try
-            // to get the instance manager via the ReactNativeHost, which only exists in 0.29.
-            Method getApplicationMethod = ReactActivity.class.getMethod("getApplication");
-            Object reactApplication = getApplicationMethod.invoke(currentActivity);
-            Class<?> reactApplicationClass = tryGetClass(REACT_APPLICATION_CLASS_NAME);
-            Method getReactNativeHostMethod = reactApplicationClass.getMethod("getReactNativeHost");
-            Object reactNativeHost = getReactNativeHostMethod.invoke(reactApplication);
-            Class<?> reactNativeHostClass = tryGetClass(REACT_NATIVE_HOST_CLASS_NAME);
-            Method getReactInstanceManagerMethod = reactNativeHostClass.getMethod("getReactInstanceManager");
-            instanceManager = (ReactInstanceManager)getReactInstanceManagerMethod.invoke(reactNativeHost);
-        } catch (Exception e) {
-            // The React Native version might be older than 0.29, or the activity does not
-            // extend ReactActivity, so we try to get the instance manager via the
-            // "mReactInstanceManager" field.
-            Class instanceManagerHolderClass = currentActivity instanceof ReactActivity
-                    ? ReactActivity.class
-                    : currentActivity.getClass();
-            Field instanceManagerField = instanceManagerHolderClass.getDeclaredField("mReactInstanceManager");
-            instanceManagerField.setAccessible(true);
-            instanceManager = (ReactInstanceManager)instanceManagerField.get(currentActivity);
-        }
-        return instanceManager;
-    }
 
-    private Class tryGetClass(String className) {
-        try {
-            return Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            return null;
-        }
+        ReactApplication reactApplication = (ReactApplication) currentActivity.getApplication();
+        instanceManager = reactApplication.getReactNativeHost().getReactInstanceManager();
+
+        return instanceManager;
     }
 
     @ReactMethod

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -105,11 +105,11 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             Field bundleLoaderField = instanceManager.getClass().getDeclaredField("mBundleLoader");
             Class<?> jsBundleLoaderClass = Class.forName("com.facebook.react.cxxbridge.JSBundleLoader");
             Method createFileLoaderMethod = null;
+            String createFileLoaderMethodName = latestJSBundleFile.toLowerCase().startsWith("assets://")
+                        ? "createAssetLoader" : "createFileLoader";
 
             Method[] methods = jsBundleLoaderClass.getDeclaredMethods();
-            for (Method method : methods) {
-                String createFileLoaderMethodName = latestJSBundleFile.toLowerCase().startsWith("assets://")
-                        ? "createAssetLoader" : "createFileLoader";
+            for (Method method : methods) {               
                 if (method.getName().equals(createFileLoaderMethodName)) {
                     createFileLoaderMethod = method;
                     break;
@@ -321,7 +321,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 JSONObject currentPackage = mUpdateManager.getCurrentPackage();
 
                 if (currentPackage == null) {
-                    promise.resolve(null);
+                    promise.resolve("");
                     return null;
                 }
 
@@ -335,14 +335,14 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 if (updateState == CodePushUpdateState.PENDING.getValue() && !currentUpdateIsPending) {
                     // The caller wanted a pending update
                     // but there isn't currently one.
-                    promise.resolve(null);
+                    promise.resolve("");
                 } else if (updateState == CodePushUpdateState.RUNNING.getValue() && currentUpdateIsPending) {
                     // The caller wants the running update, but the current
                     // one is pending, so we need to grab the previous.
                     JSONObject previousPackage = mUpdateManager.getPreviousPackage();
 
                     if (previousPackage == null) {
-                        promise.resolve(null);
+                        promise.resolve("");
                         return null;
                     }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -321,7 +321,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 JSONObject currentPackage = mUpdateManager.getCurrentPackage();
 
                 if (currentPackage == null) {
-                    promise.resolve("");
+                    promise.resolve(null);
                     return null;
                 }
 
@@ -335,14 +335,14 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 if (updateState == CodePushUpdateState.PENDING.getValue() && !currentUpdateIsPending) {
                     // The caller wanted a pending update
                     // but there isn't currently one.
-                    promise.resolve("");
+                    promise.resolve(null);
                 } else if (updateState == CodePushUpdateState.RUNNING.getValue() && currentUpdateIsPending) {
                     // The caller wants the running update, but the current
                     // one is pending, so we need to grab the previous.
                     JSONObject previousPackage = mUpdateManager.getPreviousPackage();
 
                     if (previousPackage == null) {
-                        promise.resolve("");
+                        promise.resolve(null);
                         return null;
                     }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -55,6 +55,10 @@ public class FileUtils {
     }
 
     public static void deleteDirectoryAtPath(String directoryPath) {
+        if (directoryPath == null) {
+            CodePushUtils.log("deleteDirectoryAtPath attempted with null directoryPath");
+            return;
+        }
         File file = new File(directoryPath);
         if (file.exists()) {
             deleteFileOrFolderSilently(file);

--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -1,5 +1,7 @@
 // Adapted from https://raw.githubusercontent.com/facebook/react-native/master/local-cli/generator-android/templates/src/app/react.gradle
 
+import java.nio.file.Paths;
+
 def config = project.hasProperty("react") ? project.react : [];
 def bundleAssetName = config.bundleAssetName ?: "index.android.bundle"
 
@@ -22,7 +24,10 @@ gradle.projectsEvaluated {
     def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
     if (!productFlavors) productFlavors.add('')
     def nodeModulesPath;
-    if (project.hasProperty('nodeModulesPath')) {
+    if (config.root) {
+        nodeModulesPath = Paths.get(config.root, "/node_modules");
+    }
+    else if (project.hasProperty('nodeModulesPath')) {
         nodeModulesPath = project.nodeModulesPath
     } else {
         nodeModulesPath = "../../node_modules";

--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -44,7 +44,7 @@ gradle.projectsEvaluated {
             def jsBundleDir = elvisFile(config."$jsBundleDirConfigName") ?:
                     file("$buildDir/intermediates/assets/${targetPath}")
 
-            def resourcesDirConfigName = "jsBundleDir${targetName}"
+            def resourcesDirConfigName = "resourcesDir${targetName}"
             def resourcesDir = elvisFile(config."${resourcesDirConfigName}") ?:
                     file("$buildDir/intermediates/res/merged/${targetPath}")
 

--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -52,11 +52,16 @@ gradle.projectsEvaluated {
             
             def jsBundleFile = file("$jsBundleDir/$bundleAssetName")
 
+            def resourcesMapTempFileName = "CodePushResourcesMap-" + java.util.UUID.randomUUID().toString().substring(0,8) + ".json"
+
+            // Additional node commandline arguments
+            def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
+
             // Make this task run right before the bundle task
             def recordFilesBeforeBundleCommand = tasks.create(
                     name: "recordFilesBeforeBundleCommand${targetName}",
                     type: Exec) {
-                commandLine "node", "${nodeModulesPath}/react-native-code-push/scripts/recordFilesBeforeBundleCommand.js", resourcesDir
+                commandLine (*nodeExecutableAndArgs, "${nodeModulesPath}/react-native-code-push/scripts/recordFilesBeforeBundleCommand.js", resourcesDir, resourcesMapTempFileName)
             }
 
             recordFilesBeforeBundleCommand.dependsOn("merge${targetName}Resources")
@@ -67,7 +72,7 @@ gradle.projectsEvaluated {
             def generateBundledResourcesHash = tasks.create(
                     name: "generateBundledResourcesHash${targetName}",
                     type: Exec) {
-                commandLine "node", "${nodeModulesPath}/react-native-code-push/scripts/generateBundledResourcesHash.js", resourcesDir, "$jsBundleDir/$bundleAssetName", jsBundleDir
+                commandLine (*nodeExecutableAndArgs, "${nodeModulesPath}/react-native-code-push/scripts/generateBundledResourcesHash.js", resourcesDir, "$jsBundleDir/$bundleAssetName", jsBundleDir, resourcesMapTempFileName)
             }
 
             generateBundledResourcesHash.dependsOn("bundle${targetName}JsAndAssets")

--- a/docs/setup-ios.md
+++ b/docs/setup-ios.md
@@ -117,3 +117,36 @@ To let the CodePush runtime know which deployment it should query for updates ag
 ![Deployment list](https://cloud.githubusercontent.com/assets/116461/11601733/13011d5e-9a8a-11e5-9ce2-b100498ffb34.png)
 
 In order to effectively make use of the `Staging` and `Production` deployments that were created along with your CodePush app, refer to the [multi-deployment testing](../README.md#multi-deployment-testing) docs below before actually moving your app's usage of CodePush into production.
+
+### HTTP exception domains configuration (iOS)
+
+CodePush plugin makes HTTPS requests to the following domains:
+
+- codepush.azurewebsites.net
+- codepush.blob.core.windows.net
+- codepushupdates.azureedge.net
+
+If you want to change the default HTTP security configuration for any of these domains, you have to define the [`NSAppTransportSecurity` (ATS)][ats] configuration inside your __Info.plist__ file:
+
+```xml
+<plist version="1.0">
+  <dict>
+    <!-- ...other configs... -->
+
+    <key>NSAppTransportSecurity</key>
+    <dict>
+      <key>NSExceptionDomains</key>
+      <dict>
+        <key>codepush.azurewebsites.net</key>
+        <dict><!-- read the ATS Apple Docs for available options --></dict>
+      </dict>
+    </dict>
+
+    <!-- ...other configs... -->
+  </dict>
+</plist>
+```
+
+Before doing anything, please [read the docs][ats] first.
+
+[ats]: https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -329,21 +329,25 @@ static NSString *bundleResourceSubdirectory = nil;
     if (![self binaryBundleURL]) {
         NSString *errorMessage;
 
-#if TARGET_IPHONE_SIMULATOR
-        errorMessage = @"React Native doesn't generate your app's JS bundle by default when deploying to the simulator. "
-        "If you'd like to test CodePush using the simulator, you can do one of three things depending on your React "
-        "Native version and/or preferred workflow:\n\n"
+    #ifdef DEBUG
+        #if TARGET_IPHONE_SIMULATOR
+            errorMessage = @"React Native doesn't generate your app's JS bundle by default when deploying to the simulator. "
+            "If you'd like to test CodePush using the simulator, you can do one of three things depending on your React "
+            "Native version and/or preferred workflow:\n\n"
 
-        "1. Update your AppDelegate.m file to load the JS bundle from the packager instead of from CodePush. "
-        "You can still test your CodePush update experience using this workflow (debug builds only).\n\n"
+            "1. Update your AppDelegate.m file to load the JS bundle from the packager instead of from CodePush. "
+            "You can still test your CodePush update experience using this workflow (debug builds only).\n\n"
 
-        "2. Force the JS bundle to be generated in simulator builds by removing the if block that echoes "
-        "\"Skipping bundling for Simulator platform\" in the \"node_modules/react-native/packager/react-native-xcode.sh\" file.\n\n"
+            "2. Force the JS bundle to be generated in simulator builds by removing the if block that echoes "
+            "\"Skipping bundling for Simulator platform\" in the \"node_modules/react-native/packager/react-native-xcode.sh\" file.\n\n"
 
-        "3. Deploy a release build to the simulator, which unlike debug builds, will generate the JS bundle (React Native >=0.22.0 only).";
-#else
-        errorMessage = [NSString stringWithFormat:@"The specified JS bundle file wasn't found within the app's binary. Is \"%@\" the correct file name?", [bundleResourceName stringByAppendingPathExtension:bundleResourceExtension]];
-#endif
+            "3. Deploy a release build to the simulator, which unlike debug builds, will generate the JS bundle (React Native >=0.22.0 only).";
+        #else
+            errorMessage = [NSString stringWithFormat:@"The specified JS bundle file wasn't found within the app's binary. Is \"%@\" the correct file name?", [bundleResourceName stringByAppendingPathExtension:bundleResourceExtension]];
+        #endif
+    #else
+        errorMessage = @"Something went wrong. Please verify if generated JS bundle is correct. ";
+    #endif
 
         RCTFatal([CodePushErrorUtils errorWithMessage:errorMessage]);
     }
@@ -583,7 +587,7 @@ static NSString *bundleResourceSubdirectory = nil;
     // Save the current time so that when the app is later
     // resumed, we can detect how long it was in the background.
     _lastResignedDate = [NSDate date];
-    
+
     if (_installMode == CodePushInstallModeOnNextSuspend && [[self class] isPendingUpdate:nil]) {
         _appSuspendTimer = [NSTimer scheduledTimerWithTimeInterval:_minimumBackgroundDuration
                                                          target:self

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -26,7 +26,10 @@ module.exports = (NativeCodePush) => {
         // Use the downloaded package info. Native code will save the package info
         // so that the client knows what the current package version is.
         try {
-          const downloadedPackage = await NativeCodePush.downloadUpdate(this, !!downloadProgressCallback);
+          const updatePackageCopy = Object.assign({}, this);
+          Object.keys(updatePackageCopy).forEach((key) => (typeof updatePackageCopy[key] === 'function') && delete updatePackageCopy[key]);
+
+          const downloadedPackage = await NativeCodePush.downloadUpdate(updatePackageCopy, !!downloadProgressCallback);
           reportStatusDownload && reportStatusDownload(this);
           return { ...downloadedPackage, ...local };
         } finally {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "2.1.0-beta",
+  "version": "1000.0.0-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1000.0.0-beta",
+  "version": "2.1.0-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",

--- a/scripts/generateBundledResourcesHash.js
+++ b/scripts/generateBundledResourcesHash.js
@@ -21,16 +21,18 @@ var CODE_PUSH_FOLDER_PREFIX = "CodePush";
 var CODE_PUSH_HASH_FILE_NAME = "CodePushHash";
 var CODE_PUSH_HASH_OLD_FILE_NAME = "CodePushHash.json";
 var HASH_ALGORITHM = "sha256";
-var TEMP_FILE_PATH = path.join(require("os").tmpdir(), "CodePushResourcesMap.json");
 
 var resourcesDir = process.argv[2];
 var jsBundleFilePath = process.argv[3];
 var assetsDir = process.argv[4];
+var tempFileName = process.argv[5];
+
+var tempFileLocalPath = path.join(require("os").tmpdir(), tempFileName);
 var resourceFiles = [];
 
 getFilesInFolder(resourcesDir, resourceFiles);
 
-var oldFileToModifiedTimeMap = require(TEMP_FILE_PATH);
+var oldFileToModifiedTimeMap = require(tempFileLocalPath);
 var newFileToModifiedTimeMap = {};
 
 resourceFiles.forEach(function(resourceFile) {
@@ -114,4 +116,4 @@ function fileExists(file) {
     catch (e) { return false; }
 }
 
-fs.unlinkSync(TEMP_FILE_PATH);
+fs.unlinkSync(tempFileLocalPath);

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -105,8 +105,8 @@ function getDefaultPlistPath() {
     return glob.sync(`**/${package.name}/*Info.plist`, ignoreNodeModules)[0];
 }
 
-// This is enhanced version of standard implementation of xcode 'getBuildProperty' function  
-// but allows us to narrow results by PRODUCT_NAME property also. 
+// This is enhanced version of standard implementation of xcode 'getBuildProperty' function
+// but allows us to narrow results by PRODUCT_NAME property also.
 // So we suppose that proj name should be the same as package name, otherwise fallback to default plist path searching logic
 function getBuildSettingsPropertyMatchingTargetProductName(parsedXCodeProj, prop, targetProductName, build){
     var target;
@@ -146,7 +146,7 @@ function getPlistPath(){
     var parsedXCodeProj;
 
     try {
-        var proj = xcode.project(xcodeProjectPath);      
+        var proj = xcode.project(xcodeProjectPath);
         //use sync version because there are some problems with async version of xcode lib as of current version
         parsedXCodeProj = proj.parseSync();
     }
@@ -160,14 +160,16 @@ function getPlistPath(){
     var targetProductName = package ? package.name : null;
 
     //Try to get 'Release' build of ProductName matching the package name first and if it doesn't exist then try to get any other if existing
-    var plistPathValue = getBuildSettingsPropertyMatchingTargetProductName(parsedXCodeProj, INFO_PLIST_PROJECT_KEY, targetProductName, RELEASE_BUILD_PROPERTY_NAME) || 
+    var plistPathValue = getBuildSettingsPropertyMatchingTargetProductName(parsedXCodeProj, INFO_PLIST_PROJECT_KEY, targetProductName, RELEASE_BUILD_PROPERTY_NAME) ||
         getBuildSettingsPropertyMatchingTargetProductName(parsedXCodeProj, INFO_PLIST_PROJECT_KEY, targetProductName) ||
-         parsedXCodeProj.getBuildProperty(INFO_PLIST_PROJECT_KEY, RELEASE_BUILD_PROPERTY_NAME) || 
+         parsedXCodeProj.getBuildProperty(INFO_PLIST_PROJECT_KEY, RELEASE_BUILD_PROPERTY_NAME) ||
          parsedXCodeProj.getBuildProperty(INFO_PLIST_PROJECT_KEY);
 
     if (!plistPathValue){
         return getDefaultPlistPath();
     }
 
-    return path.resolve(path.dirname(xcodeProjectPath), '..', plistPathValue);    
+    //also remove surrounding quotes from plistPathValue to get correct path resolved
+    //(see https://github.com/Microsoft/react-native-code-push/issues/534#issuecomment-302069326 for details)
+    return path.resolve(path.dirname(xcodeProjectPath), '..', plistPathValue.replace(/^"(.*)"$/, '$1'));
 }

--- a/scripts/recordFilesBeforeBundleCommand.js
+++ b/scripts/recordFilesBeforeBundleCommand.js
@@ -11,9 +11,11 @@ var path = require("path");
 
 var getFilesInFolder = require("./getFilesInFolder");
 
-var TEMP_FILE_PATH = path.join(require("os").tmpdir(), "CodePushResourcesMap.json");
 
 var resourcesDir = process.argv[2];
+var tempFileName = process.argv[3];
+
+var tempFileLocalPath = path.join(require("os").tmpdir(), tempFileName);
 var resourceFiles = [];
 
 try {
@@ -32,7 +34,7 @@ resourceFiles.forEach(function(resourceFile) {
     fileToModifiedTimeMap[resourceFile.path.substring(resourcesDir.length)] = resourceFile.mtime.getTime();
 });
 
-fs.writeFile(TEMP_FILE_PATH, JSON.stringify(fileToModifiedTimeMap), function(err) {
+fs.writeFile(tempFileLocalPath, JSON.stringify(fileToModifiedTimeMap), function(err) {
     if (err) {
         throw err;
     }

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -304,7 +304,14 @@ declare namespace CodePush {
          * Indicates that you want to install the update, but don't want to restart the
          * app until the next time the end user resumes it from the background.
          */
-        ON_NEXT_RESUME
+        ON_NEXT_RESUME,
+
+        /**
+         * Indicates that you want to install the update when the app is in the background,
+         * but only after it has been in the background for "minimumBackgroundDuration" seconds (0 by default),
+         * so that user context isn't lost unless the app suspension is long enough to not matter.
+         */
+        ON_NEXT_SUSPEND
     }
 
     /**

--- a/windows/CodePush.Net46.Test/CodePush.Net46.Test.csproj
+++ b/windows/CodePush.Net46.Test/CodePush.Net46.Test.csproj
@@ -71,6 +71,11 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Examples\CodePushDemoApp\windows\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -81,19 +86,26 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
   <ItemGroup>
     <Compile Include="ApplicationDataContainerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TelemetryManagerTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodePush.Net46\CodePush.Net46.csproj">
       <Project>{4dfe3f9f-5e15-4f17-8fd4-33ff0519348e}</Project>
       <Name>CodePush.Net46</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/windows/CodePush.Net46.Test/TelemetryManagerTest.cs
+++ b/windows/CodePush.Net46.Test/TelemetryManagerTest.cs
@@ -1,0 +1,117 @@
+﻿using CodePush.ReactNative;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CodePush.Net46.Test
+{
+    /// <summary>
+    /// Some tests for telemetry manager
+    /// As implementation of TelemetryManager was ported from android version, we do not test logic here.
+    /// Here are tests for some tricky parts of implementation, or check some data transformation that
+    /// has no full equvalent in C#
+    /// </summary>
+    [TestClass]
+    public class TelemetryManagerTest
+    {
+        #region Constants from TelemetryManager
+        //private static readonly string APP_VERSION_KEY = "appVersion";
+        private static readonly string DEPLOYMENT_FAILED_STATUS = "DeploymentFailed";
+        private static readonly string DEPLOYMENT_KEY_KEY = "deploymentKey";
+        private static readonly string DEPLOYMENT_SUCCEEDED_STATUS = "DeploymentSucceeded";
+        private static readonly string LABEL_KEY = "label";
+        private static readonly string LAST_DEPLOYMENT_REPORT_KEY = "CODE_PUSH_LAST_DEPLOYMENT_REPORT";
+        //private static readonly string PACKAGE_KEY = "package";
+        //private static readonly string PREVIOUS_DEPLOYMENT_KEY_KEY = "previousDeploymentKey";
+        //private static readonly string PREVIOUS_LABEL_OR_APP_VERSION_KEY = "previousLabelOrAppVersion";
+        private static readonly string RETRY_DEPLOYMENT_REPORT_KEY = "CODE_PUSH_RETRY_DEPLOYMENT_REPORT";
+        private static readonly string STATUS_KEY = "status";
+        #endregion
+
+        [TestMethod]
+        public void TestGetUpdateReportNoPreviousUpdate()
+        {
+            var input = new JObject();
+            input.Add(DEPLOYMENT_KEY_KEY, "depKeyParam");
+            input.Add(LABEL_KEY, "labelParam");
+
+            var output = TelemetryManager.GetUpdateReport(input);
+            Assert.IsNotNull(output);
+            Assert.IsTrue(output.ToString(Formatting.None).Contains("\"status\":\"DeploymentSucceeded\""));
+        }
+
+        [TestMethod]
+        public void TestGetUpdateReportWithPreviousUpdate()
+        {
+            SettingsManager.SetString(LAST_DEPLOYMENT_REPORT_KEY, "prevKey:prevLabel");
+            var input = new JObject();
+            input.Add(DEPLOYMENT_KEY_KEY, "depKeyParam");
+            input.Add(LABEL_KEY, "labelParam");
+
+            var output = TelemetryManager.GetUpdateReport(input);
+            Assert.IsNotNull(output);
+            Assert.IsTrue(output.ToString(Formatting.None).Contains("\"status\":\"DeploymentSucceeded\""));
+            Assert.IsTrue(output.ToString(Formatting.None).Contains("\"previousDeploymentKey\":\"prevKey\",\"previousLabelOrAppVersion\":\"prevLabel\""));
+
+            //Clean Up
+            SettingsManager.RemoveString(LAST_DEPLOYMENT_REPORT_KEY);
+        }
+
+        [TestMethod]
+        public void TestGetUpdateReportNegative()
+        {
+            var inputNoLabel = new JObject();
+            inputNoLabel.Add(DEPLOYMENT_KEY_KEY, "depKeyParam");
+            Assert.IsNull(TelemetryManager.GetUpdateReport(inputNoLabel));
+
+            var inputNoKey = new JObject();
+            inputNoKey.Add(LABEL_KEY, "labelParam");
+            Assert.IsNull(TelemetryManager.GetUpdateReport(inputNoKey));
+        }
+
+        [TestMethod]
+        public void TestRecordStatusReportWithRollback()
+        {
+            var report = new JObject();
+            report.Add(STATUS_KEY, DEPLOYMENT_FAILED_STATUS);
+
+            TelemetryManager.RecordStatusReported(report);
+            Assert.IsTrue(true);
+        }
+
+        [TestMethod]
+        public void TestRecordStatusReportWithoutRollback()
+        {
+            var reportSuccess = new JObject();
+            reportSuccess.Add(STATUS_KEY, DEPLOYMENT_SUCCEEDED_STATUS);
+            TelemetryManager.RecordStatusReported(reportSuccess);
+
+            var reportNoStatus = new JObject();
+            TelemetryManager.RecordStatusReported(reportNoStatus);
+
+            Assert.IsTrue(true);
+        }
+
+        [TestMethod]
+        public void TestStatusReportForRetrySerialization()
+        {
+            SettingsManager.RemoveString(RETRY_DEPLOYMENT_REPORT_KEY);
+            var original = new JObject();
+            original.Add("keyString", "stringValue");
+            original.Add("keyInt", 42);
+            original.Add("keyBool", true);
+
+            TelemetryManager.SaveStatusReportForRetry(original);
+
+            var stringified = SettingsManager.GetString(RETRY_DEPLOYMENT_REPORT_KEY);
+            SettingsManager.RemoveString(RETRY_DEPLOYMENT_REPORT_KEY);
+
+            Assert.IsNotNull(stringified);
+            var result = JObject.Parse(stringified);
+
+            Assert.IsTrue((bool)result.GetValue("keyBool"));
+            Assert.AreEqual(42, (int)result.GetValue("keyInt"));
+            Assert.AreEqual("stringValue", (string)result.GetValue("keyString"));
+        }
+    }
+}

--- a/windows/CodePush.Net46.Test/app.config
+++ b/windows/CodePush.Net46.Test/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/windows/CodePush.Net46.Test/packages.config
+++ b/windows/CodePush.Net46.Test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+</packages>

--- a/windows/CodePush.Net46/Adapters/Storage/ApplicationDataContainer.cs
+++ b/windows/CodePush.Net46/Adapters/Storage/ApplicationDataContainer.cs
@@ -42,7 +42,7 @@ namespace CodePush.Net46.Adapters.Storage
             }
         }
 
-        public bool Remove(TKey key)
+        public new bool Remove(TKey key)
         {
             var found = base.Remove(key);
             if (found)

--- a/windows/CodePush.Net46/CodePushUtils.cs
+++ b/windows/CodePush.Net46/CodePushUtils.cs
@@ -1,6 +1,8 @@
 ﻿using Newtonsoft.Json.Linq;
 using PCLStorage;
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Management;
 using System.Threading.Tasks;
 
@@ -8,6 +10,52 @@ namespace CodePush.ReactNative
 {
     internal partial class CodePushUtils
     {
+        class ApplicationInfo
+        {
+            public ApplicationInfo()
+            {
+                var info = FileVersionInfo.GetVersionInfo(Environment.GetCommandLineArgs()[0]);
+                Version = $"{info.FileMajorPart}.{info.FileMinorPart}.{info.FileBuildPart}";
+                CompanyName = string.IsNullOrEmpty(info.CompanyName) ? info.ProductName : info.CompanyName;
+                ProductName = info.ProductName;
+            }
+
+            public string Version { private set; get; }
+            public string CompanyName { private set; get; }
+            public string ProductName { private set; get; }
+        }
+
+        static ApplicationInfo applicationInfo = new ApplicationInfo();
+        static string _bundlePath;
+
+        internal static string GetFileBundlePrefix()
+        {
+            // For Windows desktop application the prefix of a bundle is the full path to the folder where
+            // bundle should be installed.
+            //
+            // Desktop application can be installed at any location, the most popular are:
+            // - User local data folder, in this case the bundle can be stored in the same location and be
+            // unique for the user.
+            // - Program Files folder, in this case the application is unique for the system and will be shared
+            // amoung all users of the system, the bundle should be unique for the system as well.
+            // Commonly, user has no write access to Program Files folder or at least admin privileges have to been requested.
+            // In this case the bundle will be stored in ProgramData folder as it is recommended by MS.
+
+            if (!string.IsNullOrEmpty(_bundlePath))
+            {
+                return _bundlePath;
+            }
+
+            _bundlePath = GetAppFolder();
+
+            if (!HasWriteAccessToFolder(_bundlePath))
+            {
+                _bundlePath = $"{Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), applicationInfo.CompanyName, applicationInfo.ProductName, applicationInfo.Version)}\\";
+            }
+
+            return _bundlePath;
+        }
+
         internal async static Task<JObject> GetJObjectFromFileAsync(IFile file)
         {
             string jsonString = await file.ReadAllTextAsync().ConfigureAwait(false);
@@ -92,6 +140,19 @@ namespace CodePush.ReactNative
             }
 
             return mac;
+        }
+
+        static bool HasWriteAccessToFolder(string path)
+        {
+            try
+            {
+                File.Open(Path.Combine(path, ".security-check"), FileMode.OpenOrCreate).Close();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/windows/CodePush.Net46/UpdateManager.cs
+++ b/windows/CodePush.Net46/UpdateManager.cs
@@ -8,9 +8,6 @@ using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-
-[assembly: InternalsVisibleTo("CodePush.Net46.UnitTest")]
-
 namespace CodePush.ReactNative
 {
     internal class UpdateManager

--- a/windows/CodePush.Net46/UpdateUtils.cs
+++ b/windows/CodePush.Net46/UpdateUtils.cs
@@ -63,7 +63,7 @@ namespace CodePush.ReactNative
 
         internal static async Task<IFolder> GetCodePushFolderAsync()
         {
-            var pathToCodePush = Path.Combine(CodePushUtils.GetAppFolder(), CodePushConstants.CodePushFolderPrefix);
+            var pathToCodePush = Path.Combine(CodePushUtils.GetFileBundlePrefix(), CodePushConstants.CodePushFolderPrefix);
             return await FileSystem.Current.LocalStorage.CreateFolderAsync(pathToCodePush, CreationCollisionOption.OpenIfExists).ConfigureAwait(false);
         }
     }

--- a/windows/CodePush.Shared/CodePush.Shared.projitems
+++ b/windows/CodePush.Shared/CodePush.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)InstallMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MinimumBackgroundListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SettingsManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TelemetryManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UpdateState.cs" />
   </ItemGroup>
 </Project>

--- a/windows/CodePush.Shared/CodePushConstants.cs
+++ b/windows/CodePush.Shared/CodePushConstants.cs
@@ -27,7 +27,7 @@
         internal const string UnzippedFolderName = "unzipped";
 #if WINDOWS_UWP
         internal const string AssetsBundlePrefix = "ms-appx:///ReactAssets/";
-        internal const string FileBundlePrefix = "ms-appdata:///local";
+        internal const string FileBundlePrefix = "ms-appdata:///local/";
 #else
         internal const string AssetsBundlePrefix = "ReactAssets/";
 #endif

--- a/windows/CodePush.Shared/CodePushReactPackage.cs
+++ b/windows/CodePush.Shared/CodePushReactPackage.cs
@@ -105,7 +105,8 @@ namespace CodePush.ReactNative
             {
                 CodePushUtils.LogBundleUrl(packageFile.Path);
                 IsRunningBinaryVersion = false;
-                return CodePushUtils.GetFileBundlePrefix() + packageFile.Path.Replace(CodePushUtils.GetAppFolder(), "").Replace("\\", "/");
+
+                return CodePushUtils.GetFileBundlePrefix() + CodePushUtils.ExtractSubFolder(packageFile.Path);
             }
             else
             {

--- a/windows/CodePush.Shared/CodePushReactPackage.cs
+++ b/windows/CodePush.Shared/CodePushReactPackage.cs
@@ -17,8 +17,9 @@ namespace CodePush.ReactNative
         internal string AppVersion { get; private set; }
         internal string DeploymentKey { get; private set; }
         internal string AssetsBundleFileName { get; private set; }
-        internal bool DidUpdate { get; private set; }
-        internal bool IsRunningBinaryVersion { get; set; }
+        internal bool NeedToReportRollback { get; set; } = false;
+        internal bool DidUpdate { get; private set; } = false;
+        internal bool IsRunningBinaryVersion { get; private set; } = false;
         internal ReactPage MainPage { get; private set; }
         internal UpdateManager UpdateManager { get; private set; }
 
@@ -28,9 +29,6 @@ namespace CodePush.ReactNative
             DeploymentKey = deploymentKey;
             MainPage = mainPage;
             UpdateManager = new UpdateManager();
-            IsRunningBinaryVersion = false;
-            // TODO implement telemetryManager 
-            // _codePushTelemetryManager = new CodePushTelemetryManager(this.applicationContext, CODE_PUSH_PREFERENCES);
 
             if (CurrentInstance != null)
             {
@@ -129,6 +127,10 @@ namespace CodePush.ReactNative
 
         internal void InitializeUpdateAfterRestart()
         {
+            // Reset the state which indicates that
+            // the app was just freshly updated.
+            DidUpdate = false;
+
             JObject pendingUpdate = SettingsManager.GetPendingUpdate();
             if (pendingUpdate != null)
             {
@@ -138,6 +140,7 @@ namespace CodePush.ReactNative
                     // Pending update was initialized, but notifyApplicationReady was not called.
                     // Therefore, deduce that it is a broken update and rollback.
                     CodePushUtils.Log("Update did not finish loading the last time, rolling back to a previous version.");
+                    NeedToReportRollback = true;
                     RollbackPackageAsync().Wait();
                 }
                 else

--- a/windows/CodePush.Shared/CodePushUtils.cs
+++ b/windows/CodePush.Shared/CodePushUtils.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
+using System.IO;
 #if WINDOWS_UWP
 using Windows.ApplicationModel;
 using Windows.Storage;
-#else
-using System.IO;
 #endif
 
 namespace CodePush.ReactNative
@@ -38,8 +38,7 @@ namespace CodePush.ReactNative
 #if WINDOWS_UWP
             return Package.Current.Id.Version.Major + "." + Package.Current.Id.Version.Minor + "." + Package.Current.Id.Version.Build;
 #else
-            var version = FileVersionInfo.GetVersionInfo(Environment.GetCommandLineArgs()[0]);
-            return $"{version.FileMajorPart}.{version.FileMinorPart}.{version.FileBuildPart}";
+            return applicationInfo.Version;
 #endif
         }
 
@@ -61,13 +60,10 @@ namespace CodePush.ReactNative
 #endif
         }
 
-        internal static string GetFileBundlePrefix()
+        internal static string ExtractSubFolder(string fullPath)
         {
-#if WINDOWS_UWP
-            return CodePushConstants.FileBundlePrefix;
-#else
-            return GetAppFolder();
-#endif
+            var codePushSubPathArray = fullPath.Split(Path.DirectorySeparatorChar);
+            return String.Join("/", codePushSubPathArray.SkipWhile((value, index) => codePushSubPathArray.Length - index > 4).ToArray());
         }
 
     }

--- a/windows/CodePush.Shared/SettingsManager.cs
+++ b/windows/CodePush.Shared/SettingsManager.cs
@@ -129,5 +129,20 @@ namespace CodePush.ReactNative
 
             Settings.Values[CodePushConstants.PendingUpdateKey] = JsonConvert.SerializeObject(pendingUpdate);
         }
+
+        internal static void SetString(string key, string value)
+        {
+            Settings.Values[key] = value;
+        }
+
+        internal static string GetString(string key)
+        {
+            return (string)Settings.Values[key];
+        }
+
+        internal static void RemoveString(string key)
+        {
+            Settings.Values.Remove(key);
+        }
     }
 }

--- a/windows/CodePush.Shared/TelemetryManager.cs
+++ b/windows/CodePush.Shared/TelemetryManager.cs
@@ -1,0 +1,250 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CodePush.Net46.Test")]
+
+namespace CodePush.ReactNative
+{
+    /// <summary>
+    /// Implementation is ported from 
+    /// android\app\src\main\java\com\microsoft\codepush\react\CodePushTelemetry.java
+    /// I've tried to leave all logic, comments and structure without significant modification.
+    /// </summary>
+
+    internal class TelemetryManager
+    {
+        #region Constants
+        private static readonly string APP_VERSION_KEY = "appVersion";
+        private static readonly string DEPLOYMENT_FAILED_STATUS = "DeploymentFailed";
+        private static readonly string DEPLOYMENT_KEY_KEY = "deploymentKey";
+        private static readonly string DEPLOYMENT_SUCCEEDED_STATUS = "DeploymentSucceeded";
+        private static readonly string LABEL_KEY = "label";
+        private static readonly string LAST_DEPLOYMENT_REPORT_KEY = "CODE_PUSH_LAST_DEPLOYMENT_REPORT";
+        private static readonly string PACKAGE_KEY = "package";
+        private static readonly string PREVIOUS_DEPLOYMENT_KEY_KEY = "previousDeploymentKey";
+        private static readonly string PREVIOUS_LABEL_OR_APP_VERSION_KEY = "previousLabelOrAppVersion";
+        private static readonly string RETRY_DEPLOYMENT_REPORT_KEY = "CODE_PUSH_RETRY_DEPLOYMENT_REPORT";
+        private static readonly string STATUS_KEY = "status";
+        #endregion
+
+        #region Internal methods
+
+        internal static JObject GetBinaryUpdateReport(string appVersion)
+        {
+            var previousStatusReportIdentifier = GetPreviousStatusReportIdentifier();
+
+            if (previousStatusReportIdentifier == null)
+            {
+                ClearRetryStatusReport();
+
+                var report = new JObject();
+                report.Add(APP_VERSION_KEY, appVersion);
+                return report;
+            }
+
+            if (!previousStatusReportIdentifier.Equals(appVersion))
+            {
+                ClearRetryStatusReport();
+
+                var report = new JObject();
+                report.Add(APP_VERSION_KEY, appVersion);
+                if (IsStatusReportIdentifierCodePushLabel(previousStatusReportIdentifier))
+                {
+                    var previousDeploymentKey = GetDeploymentKeyFromStatusReportIdentifier(previousStatusReportIdentifier);
+                    var previousLabel = GetVersionLabelFromStatusReportIdentifier(previousStatusReportIdentifier);
+
+                    report.Add(PREVIOUS_DEPLOYMENT_KEY_KEY, previousDeploymentKey);
+                    report.Add(PREVIOUS_LABEL_OR_APP_VERSION_KEY, previousLabel);
+                }
+                else
+                {
+                    // Previous status report was with a binary app version.
+                    report.Add(PREVIOUS_LABEL_OR_APP_VERSION_KEY, previousStatusReportIdentifier);
+                }
+                return report;
+            }
+
+            return null;
+        }
+
+        internal static JObject GetRetryStatusReport()
+        {
+            var retryStatusReportString = SettingsManager.GetString(RETRY_DEPLOYMENT_REPORT_KEY);
+
+            if (retryStatusReportString != null)
+            {
+                ClearRetryStatusReport();
+                try
+                {
+                    var report = JObject.Parse(retryStatusReportString);
+                    return report;
+                }
+                catch (Exception)
+                {
+                    //TODO: should be reported error
+                }
+            }
+
+            return null;
+        }
+
+        internal static JObject GetRollbackReport(JObject lastFailedPackage)
+        {
+            var report = new JObject();
+            report.Add(STATUS_KEY, DEPLOYMENT_FAILED_STATUS);
+            report.Add(PACKAGE_KEY, lastFailedPackage);
+
+            return report;
+        }
+
+        internal static JObject GetUpdateReport(JObject currentPackage)
+        {
+            var currentPackageIdentifier = GetPackageStatusReportIdentifier(currentPackage);
+            if (currentPackageIdentifier == null)
+            {
+                return null;
+            }
+
+            var previousStatusReportIdentifier = GetPreviousStatusReportIdentifier();
+            if (previousStatusReportIdentifier == null)
+            {
+                ClearRetryStatusReport();
+                var report = new JObject();
+                report.Add(PACKAGE_KEY, currentPackage);
+                report.Add(STATUS_KEY, DEPLOYMENT_SUCCEEDED_STATUS);
+                return report;
+            }
+
+            if (!previousStatusReportIdentifier.Equals(currentPackageIdentifier))
+            {
+                ClearRetryStatusReport();
+                var report = new JObject();
+                report.Add(PACKAGE_KEY, currentPackage);
+                report.Add(STATUS_KEY, DEPLOYMENT_SUCCEEDED_STATUS);
+
+                if (IsStatusReportIdentifierCodePushLabel(previousStatusReportIdentifier))
+                {
+                    var previousDeploymentKey = GetDeploymentKeyFromStatusReportIdentifier(previousStatusReportIdentifier);
+                    var previousLabel = GetVersionLabelFromStatusReportIdentifier(previousStatusReportIdentifier);
+
+                    report.Add(PREVIOUS_DEPLOYMENT_KEY_KEY, previousDeploymentKey);
+                    report.Add(PREVIOUS_LABEL_OR_APP_VERSION_KEY, previousLabel);
+                }
+                else
+                {
+                    // Previous status report was with a binary app version.
+                    report.Add(PREVIOUS_LABEL_OR_APP_VERSION_KEY, previousStatusReportIdentifier);
+                }
+
+                return report;
+            }
+
+            return null;
+        }
+
+        internal static void RecordStatusReported(JObject statusReport)
+        {
+            // We don't need to record rollback reports, so exit early if that's what was specified.
+            var status = (string)statusReport.GetValue(STATUS_KEY);
+            if ((!string.IsNullOrEmpty(status)) && DEPLOYMENT_FAILED_STATUS.Equals(status))
+            {
+                return;
+            }
+
+            var appVersion = (string)statusReport.GetValue(APP_VERSION_KEY);
+            if (!string.IsNullOrEmpty(appVersion))
+            {
+                SaveStatusReportedForIdentifier(appVersion);
+            }
+            else
+            {
+                var package = (JObject)statusReport.GetValue(PACKAGE_KEY);
+                if (package == null)
+                {
+                    return;
+                }
+
+                var packageIdentifier = GetPackageStatusReportIdentifier(package);
+                SaveStatusReportedForIdentifier(packageIdentifier);
+            }
+        }
+
+        internal static void SaveStatusReportForRetry(JObject statusReport)
+        {
+            SettingsManager.SetString(RETRY_DEPLOYMENT_REPORT_KEY, statusReport.ToString(Formatting.None));
+        }
+
+        #endregion
+
+        #region Private methods
+        static string GetPackageStatusReportIdentifier(JObject updatePackage)
+        {
+            // Because deploymentKeys can be dynamically switched, we use a
+            // combination of the deploymentKey and label as the packageIdentifier.
+            try
+            {
+                var deploymentKey = (string)updatePackage[DEPLOYMENT_KEY_KEY];
+                var label = (string)updatePackage[LABEL_KEY];
+                if (string.IsNullOrEmpty(deploymentKey) || string.IsNullOrEmpty(label))
+                {
+                    return null;
+                }
+
+                return $"{deploymentKey}:{label}";
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        static string GetPreviousStatusReportIdentifier()
+        {
+            return SettingsManager.GetString(LAST_DEPLOYMENT_REPORT_KEY);
+        }
+
+        static private void ClearRetryStatusReport()
+        {
+            SettingsManager.RemoveString(RETRY_DEPLOYMENT_REPORT_KEY);
+        }
+
+        static bool IsStatusReportIdentifierCodePushLabel(string statusReportIdentifier)
+        {
+            return (!string.IsNullOrEmpty(statusReportIdentifier)) && statusReportIdentifier.Contains(":");
+        }
+
+        static string GetDeploymentKeyFromStatusReportIdentifier(string statusReportIdentifier)
+        {
+            string[] parsedIdentifier = statusReportIdentifier.Split(':');
+            if (parsedIdentifier.Length > 0)
+            {
+                return parsedIdentifier[0];
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        static string GetVersionLabelFromStatusReportIdentifier(string statusReportIdentifier)
+        {
+            string[] parsedIdentifier = statusReportIdentifier.Split(':');
+            if (parsedIdentifier.Length > 1)
+            {
+                return parsedIdentifier[1];
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        static void SaveStatusReportedForIdentifier(string appVersionOrPackageIdentifier)
+        {
+            SettingsManager.SetString(LAST_DEPLOYMENT_REPORT_KEY, appVersionOrPackageIdentifier);
+        }
+        #endregion
+    }
+}

--- a/windows/CodePush/CodePushUtils.cs
+++ b/windows/CodePush/CodePushUtils.cs
@@ -9,6 +9,11 @@ namespace CodePush.ReactNative
 {
     internal partial class CodePushUtils
     {
+        internal static string GetFileBundlePrefix()
+        {
+            return CodePushConstants.FileBundlePrefix;
+        }
+
         internal async static Task<JObject> GetJObjectFromFileAsync(StorageFile file)
         {
             string jsonString = await FileIO.ReadTextAsync(file).AsTask().ConfigureAwait(false);


### PR DESCRIPTION
We seen our builds break over in doof start failing  because publishing with codepush fails.  After rdping into the master build, I can see that the publish command is throwing an error:
 `App Doof uses a platform type not supported by CodePush: "UWP"`.  I have opened an issue: github.com/Microsoft/code-push/issues/462 on the codepush cli as I believe this is the source of the issue, however admittedly my understanding of the SDK portion of codepush is limited, so I opened this pull request to explore whether this issue could be possibly related to any needed updates to the clientside sdk.